### PR TITLE
Add options to match different tags or classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -64,6 +64,35 @@
             "type": "boolean",
             "default": "true",
             "markdownDescription": "%config.preview.iconFill.description%"
+          },
+          "material-icons-intellisense.matches.matchClasses": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "material-symbols-outlined",
+              "material-symbols-rounded",
+              "material-symbols-sharp",
+              "material-icons",
+              "material-icons-outlined",
+              "material-icons-round",
+              "material-icons-sharp",
+              "material-icons-two-tone"
+            ],
+            "markdownDescription": "%config.matches.matchClasses.description%"
+          },
+          "material-icons-intellisense.matches.matchTags": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "span"
+            ],
+            "markdownDescription": "%config.matches.matchTags.description%"
           }
         }
       }
@@ -78,14 +107,18 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.91.0",
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
+    "@types/regexp.escape": "^2.0.0",
+    "@types/vscode": "^1.91.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.11.0",
-    "eslint": "^8.57.0",
-    "typescript": "^5.4.5",
     "@vscode/test-cli": "^0.0.9",
-    "@vscode/test-electron": "^2.4.0"
+    "@vscode/test-electron": "^2.4.0",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "regexp.escape": "^2.0.1"
   }
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,5 +3,7 @@
   "config.preview.backgroundColor.description": "Background color of the preview icon. Supports any valid CSS color value.",
   "config.preview.foregroundColor.description": "Foreground color of the preview icon. Supports any valid CSS color value.",
   "config.version.description": "Material Icons major version to use. More information at [Material Icons](https://github.com/google/material-design-icons?tab=readme-ov-file#material-symbols).",
-  "config.preview.color.patternErrorMessage": "Invalid color format. Use a valid CSS color value."
+  "config.preview.color.patternErrorMessage": "Invalid color format. Use a valid CSS color value.",
+  "config.matches.matchClasses.description": "Match any of the listed classes.",
+  "config.matches.matchTags.description": "Match any of the listed tags."
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,8 @@ function registerProviders(context: vscode.ExtensionContext) {
   const data = require(path.join(path.dirname(__dirname), `data/material-v${config.version}`, "icons.json")) as Record<string, IconRaw>;
   const icons = Object.entries(data).map(([name, entry]) => new Icon(name, entry, config));
 
-  const provideCompletionItems = new CompletionProvider(icons);
-  const provideHoverItems = new HoverProvider(icons);
+  const provideCompletionItems = new CompletionProvider(icons, config.matches);
+  const provideHoverItems = new HoverProvider(icons, config.matches);
 
   disposables.push(
     vscode.languages.registerCompletionItemProvider(selector, provideCompletionItems),

--- a/src/providers/completion-provider.ts
+++ b/src/providers/completion-provider.ts
@@ -1,18 +1,20 @@
 import { CompletionItem, CompletionItemProvider, Position, ProviderResult, TextDocument } from "vscode";
 import { match } from "../utils/match";
-import { Icon } from "../utils/types";
+import { Icon, Matches } from "../utils/types";
 
 export class CompletionProvider implements CompletionItemProvider {
   private readonly partialCompletionItems: CompletionItem[] = [];
   private readonly completionItems: Map<string, CompletionItem> = new Map();
+  private readonly matchOptions: Matches;
 
-  constructor(icons: Icon[]) {
+  constructor(icons: Icon[], matchOptions: Matches) {
+    this.matchOptions = matchOptions;
     this.partialCompletionItems = icons.map(icon => icon.partialCompletionItem);
     this.completionItems = new Map(icons.map(icon => [icon.name, icon.completionItem]));
   }
 
   provideCompletionItems(document: TextDocument, position: Position): ProviderResult<CompletionItem[]> {
-    if (match(document, position)) {
+    if (match(document, position, this.matchOptions)) {
       return this.partialCompletionItems;
     }
 

--- a/src/providers/hover-provider.ts
+++ b/src/providers/hover-provider.ts
@@ -1,11 +1,13 @@
 import { Hover, HoverProvider as IHoverProvider, Position, ProviderResult, Range, TextDocument } from "vscode";
 import { match } from "../utils/match";
-import { Icon } from "../utils/types";
+import { Icon, Matches } from "../utils/types";
 
 export class HoverProvider implements IHoverProvider {
   private readonly hoverItems: Map<string, Hover>;
+  private readonly matchOptions: Matches;
 
-  constructor(icons: Icon[]) {
+  constructor(icons: Icon[], matchOptions: Matches) {
+    this.matchOptions = matchOptions;
     this.hoverItems = new Map(icons.map(icon => [icon.name, icon.hoverItem]));
   }
 
@@ -15,7 +17,7 @@ export class HoverProvider implements IHoverProvider {
       return;
     }
 
-    if (!match(document, wordRange.end)) {
+    if (!match(document, wordRange.end, this.matchOptions)) {
       return;
     }
 

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode";
-import { MaterialIconsVersion, PreviewStyle } from "./types";
+import { Matches, MaterialIconsVersion, PreviewStyle } from "./types";
 
 export interface Configuration {
   readonly version: MaterialIconsVersion;
   readonly previewStyle: PreviewStyle;
+  readonly matches: Matches;
 }
 
 export enum ConfigKey {
@@ -11,17 +12,43 @@ export enum ConfigKey {
   PreviewBackgroundColor = "preview.backgroundColor",
   PreviewForegroundColor = "preview.foregroundColor",
   PreviewiconFill = "preview.iconFill",
+  MatchClasses = "matches.matchClasses",
+  MatchTags = "matches.matchTags",
 }
 
 export function loadConfiguration(): Configuration {
-  const config = vscode.workspace.getConfiguration("material-icons-intellisense");
+  const config = vscode.workspace.getConfiguration(
+    "material-icons-intellisense"
+  );
 
-  const version = config.get<MaterialIconsVersion>("version", MaterialIconsVersion.V3);
+  const version = config.get<MaterialIconsVersion>(
+    "version",
+    MaterialIconsVersion.V3
+  );
   const previewStyle = {
-    backgroundColor: config.get<string>(ConfigKey.PreviewBackgroundColor, "#ffffff"),
-    foregroundColor: config.get<string>(ConfigKey.PreviewForegroundColor, "#000000"),
+    backgroundColor: config.get<string>(
+      ConfigKey.PreviewBackgroundColor,
+      "#ffffff"
+    ),
+    foregroundColor: config.get<string>(
+      ConfigKey.PreviewForegroundColor,
+      "#000000"
+    ),
     iconFill: config.get<boolean>(ConfigKey.PreviewiconFill, true),
   };
+  const matches = {
+    matchClasses: config.get<string[]>(ConfigKey.MatchClasses, [
+      "material-symbols-outlined",
+      "material-symbols-rounded",
+      "material-symbols-sharp",
+      "material-icons",
+      "material-icons-outlined",
+      "material-icons-round",
+      "material-icons-sharp",
+      "material-icons-two-tone",
+    ]),
+    matchTags: config.get<string[]>(ConfigKey.MatchTags, ["span"]),
+  };
 
-  return { version, previewStyle };
+  return { version, previewStyle, matches };
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,6 +21,11 @@ export enum MaterialIconsVersion {
   V4 = "4",
 }
 
+export interface Matches {
+  matchClasses: string[];
+  matchTags: string[];
+}
+
 const SVG_VIEWBOX: Record<MaterialIconsVersion, string> = {
   [MaterialIconsVersion.V3]: "-2 -2 28 28",
   [MaterialIconsVersion.V4]: "0 -960 960 960",


### PR DESCRIPTION
The PR adds:
- `material-icons-intellisense.matches.matchClasses`
- `material-icons-intellisense.matches.matchTags`

Both are string arrays with unique values. The arrays are escaped using [regexp.escape](https://www.npmjs.com/package/regexp.escape) and joined with a `|` character, then checked in the `match()` function.